### PR TITLE
Add CODEOWNERS file to current hash used by NEMSfv3gfs GitHub NCAR master

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,0 +1,14 @@
+# Lines starting with '#' are comments.
+# Each line is a file pattern followed by one or more owners.
+
+# These owners will be the default owners for everything in the repo.
+#*       @defunkt
+*       @climbfuji @llpcarson @grantfirl
+
+# Order is important. The last matching pattern has the most precedence.
+# So if a pull request only touches javascript files, only these owners
+# will be requested to review.
+#*.js    @octocat @github/js
+
+# You can also use email addresses if you prefer.
+#docs/*  docs@example.com


### PR DESCRIPTION
Add CODEOWNERS file to current hash used by NEMSfv3gfs GitHub NCAR master / NEMSfv3gfs gerrit master (3063a4cd337bab3de738c7ee16aa91952d1c180f)

Code identical except for newly added CODEOWNERS file

No testing required, code can be merged after review/approval.